### PR TITLE
added monthly schedule function

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -141,5 +141,5 @@ def start_bot():
 
 thread_sched = Thread(target=app_scheduler.schedule_check, name="sched")
 thread_sched.start()
-app_scheduler.schedule_daily(func=assign_active_member, args=client, tag="daily")
+app_scheduler.schedule_monthly(func=assign_active_member, args=client, tag="daily")
 start_bot()

--- a/src/others/scheduler.py
+++ b/src/others/scheduler.py
@@ -1,4 +1,5 @@
 import time
+from datetime import datetime
 
 import schedule
 
@@ -17,11 +18,18 @@ class Scheduler:
     def starter(self, f, args=None):
         self.main_loop.create_task(f(args))
 
+    def monthly_starter(self, f, args=None):
+        if datetime.now().day == 1:
+            self.main_loop.create_task(f(args))
+
     def clear_tag(self, tag):
         schedule.clear(str(tag))
 
     def schedule_daily(self, func, tag, args=None):
         schedule.every().day.at(x).do(self.starter, func, args).tag(str(tag))
+
+    def schedule_monthly(self, func, tag, args=None):  # scheduling for large time intervals should be avoided https://github.com/dbader/schedule/issues/73
+        schedule.every().day.at(x).do(self.monthly_starter, func, args).tag(str(tag))
 
     def schedule_check(self):
         SHL.info("Started scheduler.")


### PR DESCRIPTION
using `every().day` because large time intervals (`every(4).weeks`) should be avoided: see [here](https://github.com/dbader/schedule/issues/73).